### PR TITLE
Don't choke on Solr dynamic fields

### DIFF
--- a/src/main/java/com/scaleunlimited/cascading/scheme/core/SolrSchemeUtil.java
+++ b/src/main/java/com/scaleunlimited/cascading/scheme/core/SolrSchemeUtil.java
@@ -81,20 +81,19 @@ public class SolrSchemeUtil {
             }
 
             IndexSchema schema = core.getLatestSchema();
-            Map<String, SchemaField> solrFields = schema.getFields();
             Set<String> schemeFieldnames = new HashSet<String>();
 
             for (int i = 0; i < schemeFields.size(); i++) {
                 String fieldName = schemeFields.get(i).toString();
-                if (!solrFields.containsKey(fieldName)) {
+                if (schema.getFieldOrNull(fieldName) == null) {
                     throw new TapException("Sink field name doesn't exist in Solr schema: " + fieldName);
                 }
-                
                 schemeFieldnames.add(fieldName);
             }
 
-            for (String solrFieldname : solrFields.keySet()) {
-                SchemaField solrField = solrFields.get(solrFieldname);
+            for (Map.Entry<String, SchemaField> e : schema.getFields().entrySet()) {
+                String solrFieldname = e.getKey();
+                SchemaField solrField = e.getValue();
                 if (solrField.isRequired() && !schemeFieldnames.contains(solrFieldname)) {
                     throw new TapException("No sink field name for required Solr field: " + solrFieldname);
                 }

--- a/src/test/java/com/scaleunlimited/cascading/scheme/core/AbstractSolrSchemeTest.java
+++ b/src/test/java/com/scaleunlimited/cascading/scheme/core/AbstractSolrSchemeTest.java
@@ -107,7 +107,18 @@ public abstract class AbstractSolrSchemeTest extends Assert {
     }
     
     protected void testSimpleIndexing() throws Exception {
-        final Fields testFields = new Fields("id", "name", "price", "cat", "inStock", "image");
+        final Fields testFields = new Fields(
+                "id",
+                "name",
+                "price",
+                "cat",
+                "inStock",
+                "image",
+
+                // These are Solr dynamic fields
+                "foo_txt",
+                "bar_txt"
+        );
 
         final String in = getTestDir() + "testSimpleIndexing/in";
         final String out = getTestDir() + "testSimpleIndexing/out";
@@ -123,6 +134,8 @@ public abstract class AbstractSolrSchemeTest extends Assert {
         t.add(new Tuple("wordprocessor", "Japanese"));
         t.add(true);
         t.add(imageData);
+        t.add("Some text");
+        t.add("Some more text");
         write.add(t);
         
         t = new Tuple();
@@ -135,6 +148,11 @@ public abstract class AbstractSolrSchemeTest extends Assert {
         BytesWritable bw = new BytesWritable(imageData);
         bw.setCapacity(imageData.length + 10);
         t.add(bw);
+        t.add("Four score and seven years ago our fathers brought forth on "
+                      + "this continent, a new nation, conceived in Liberty, "
+                      + "and dedicated to the proposition that all men are "
+                      + "created equal.");
+        t.add("Ceci n'est pas une épreuve");
         write.add(t);
         write.close();
 


### PR DESCRIPTION
Solr schemas support a `dynamicField` xml element that allows documents to have an open-ended field set that matches input field names by wildcard.  This scheme currently fails on such field names.  This pull request modifies the unit test suite to exercise such fields (which were already defined in the test schema), and fixes the validation to not choke on them.